### PR TITLE
Update to Julia v1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 1.0
   - nightly
 notifications:
   email: false

--- a/src/WRS.jl
+++ b/src/WRS.jl
@@ -2,8 +2,9 @@ __precompile__()
 module WRS
 
 using Distributions
+using Distributed
 
-export hd
+export hd, pb2gen
 
 # This implements (3.16) from (2017) p. 71-72
 function hd(X, q=0.5, issorted=false)


### PR DESCRIPTION
The only update needed was that `pmap` is now in the Distributed package, not Base. I also added for it to export `pb2gen`.